### PR TITLE
Remove field_types since it does not seem to be used and breaks with CKAN 2.5

### DIFF
--- a/ckanext/iati/logic/validators.py
+++ b/ckanext/iati/logic/validators.py
@@ -4,7 +4,6 @@ from dateutil.parser import parse as date_parse
 from ckan.logic import get_action
 from ckan import new_authz
 from ckan.lib.navl.dictization_functions import unflatten, Invalid
-from ckan.lib.field_types import DateType, DateConvertError
 
 from ckanext.iati.lists import FILE_TYPES, COUNTRIES
 


### PR DESCRIPTION
field_types seems to have been removed sometime between CKAN 2.1 and 2.5 and this doesn't allow CKAN 2.5 to start. Looking at the code this doesn't seem to be used?