### PR TITLE
Add banner to IATI Registry to inform users of downtime

### DIFF
--- a/ckanext/iati/theme/templates/header.html
+++ b/ckanext/iati/theme/templates/header.html
@@ -15,6 +15,9 @@
 
       </div>
   {% endif %}
+  <div class="alert" style="text-align: center">
+    <strong>The IATI Registry will be unavailable on Thursday 23rd June (Xam - Ypm) due to maintenance. <a href="http://www.aidtransparency.net">More information</a>.</strong>
+  </div>
   <a href="#content" class="hide">{{ _('Skip to primary content') }}</a>
   <header id="header">
     <div class="container">

--- a/ckanext/iati/theme/templates/header.html
+++ b/ckanext/iati/theme/templates/header.html
@@ -16,7 +16,7 @@
       </div>
   {% endif %}
   <div class="alert" style="text-align: center">
-    <strong>The IATI Registry will be unavailable on Thursday 23rd June (Xam - Ypm) due to maintenance. <a href="http://www.aidtransparency.net">More information</a>.</strong>
+    <strong>The IATI Registry will be unavailable on Thursday 23 June (19:00 - 23:00 UK time) due to maintenance. <a href="http://www.aidtransparency.net/news/scheduled-downtime-for-the-iati-registry-on-thursday-23-june">More information here</a>.</strong>
   </div>
   <a href="#content" class="hide">{{ _('Skip to primary content') }}</a>
   <header id="header">


### PR DESCRIPTION
Please review this code to confirm this is the correct approach to add a banner to all pages on the IATI Registry (this banner will only need to be visible for a week, and these changes can then be reverted).

If all ok, please merge into the IATI extension and deploy to the site ASAP.

Many thanks,
Dale
IATI Developer