### PR TITLE
Adjust text on banner to notify users of forthcoming upgrade

### DIFF
--- a/ckanext/iati/theme/templates/header.html
+++ b/ckanext/iati/theme/templates/header.html
@@ -17,7 +17,7 @@
   {% endif %}
   <div class="alert" style="text-align: center">
     <strong>The IATI Registry will be upgraded in early October including changes to API functionality.
-      <a href="http://www.aidtransparency.net/news/important-changes-to-the-iati-registry-api">More information here</a>.
+      Do you need to take action? <a href="http://www.aidtransparency.net/news/important-changes-to-the-iati-registry-api">More information here</a>.
     </strong>
   </div>
   <a href="#content" class="hide">{{ _('Skip to primary content') }}</a>


### PR DESCRIPTION
Small adjustment to the text on the header banner, which currently shows as:

![image](https://cloud.githubusercontent.com/assets/8247168/18125516/7756d0dc-6f6e-11e6-82f5-2ae42baa239a.png)


The desired output should be:

<img width="1018" alt="1472566502" src="https://cloud.githubusercontent.com/assets/8247168/18125503/6b955840-6f6e-11e6-9b32-f065459705cf.png">

If this pull request looks ok, can we merge and deploy to the current live site: https://iatiregistry.org/