### PR TITLE
Amend header warning message on v2.5 staging site with version number

### DIFF
--- a/ckanext/iati/theme/templates/header.html
+++ b/ckanext/iati/theme/templates/header.html
@@ -9,9 +9,8 @@
 {% block header_wrapper %}
   {% if 'staging' in request.host or 'test' in request.host %}
       <div class="alert">
-        <strong>Warning!</strong> This is a staging site. It runs the same code base as the
-        <a href="http://iatiregistry.org">production one</a> but data might be out of date.
-        Be aware that all new data in this instance might be deleted at any time.
+        <strong>Warning!</strong> This is a staging site. It runs an updated code base (<a href="http://docs.ckan.org/en/ckan-2.5.2/changelog.html">CKAN v2.5.2</a>) compared to the
+        <a href="http://iatiregistry.org">current live version</a> (which uses CKAN v2.1.4). Data might be out of date and be aware that all new data in this instance might be deleted at any time.
 
       </div>
   {% endif %}


### PR DESCRIPTION
Small adjustment to the text on the header banner, which currently shows as:

![image](https://cloud.githubusercontent.com/assets/8247168/18126070/5e5b43a8-6f71-11e6-9ee0-ca1df09f3692.png)


The desired output should be:

![image](https://cloud.githubusercontent.com/assets/8247168/18126048/4922e8c4-6f71-11e6-9b7e-e9de61e0304b.png)


If this pull request looks ok, can we merge and deploy to the staging site: https://iati-staging.ckan.io/