### PR TITLE
Fix links to opendevtoolkit in light of the new domain

### DIFF
--- a/ckanext/iati/theme/templates/home/index.html
+++ b/ckanext/iati/theme/templates/home/index.html
@@ -38,7 +38,7 @@
         <a href="{{ h.url_for(controller='ckanext.iati.controllers.static:StaticController', action='dashboard') }}" class="block">Dashboard</a>
         <p>The IATI Dashboard provides statistics, charts and metrics on IATI data</p>
         <ul>
-          <li><a href="http://opendevtoolkit.net/en-US/tools/ ">See a list of projects, websites and tools that utilise IATI data</a></li>
+          <li><a href="http://opendevtoolkit.org">See a list of projects, websites and tools that utilise IATI data</a></li>
           <li><a href="/registry-api">Developer?  Resources to help.</a></li>
         </ul>
       </div>

--- a/ckanext/iati/theme/templates/static/registry-api.html
+++ b/ckanext/iati/theme/templates/static/registry-api.html
@@ -6,7 +6,7 @@
 
   <h1>Registry API</h1>
 
-  <p>The IATI Registry holds meta-data on files published in the <a href="http://www.iatistandard.org" target="_blank">IATI XML format</a>. The files themselves are stored in different places across the web, and you will need to fetch and process the original files yourself. If you are looking for an API directly onto IATI data, you can use the <a href="http://datastore.iatistandard.org/" target="_blank">IATI DataStore</a> or consult the <a href="http://opendevtoolkit.net" target="_blank">Open Development Toolkit</a> to learn about other third-party platforms. If in doubt, ask on IATI <a href="http://discuss.iatistandard.org/">Discuss</a> or email the technical team on <a href="mailto:support@iatistandard.org">support@iatistandard.org</a>.</p>
+  <p>The IATI Registry holds meta-data on files published in the <a href="http://www.iatistandard.org" target="_blank">IATI XML format</a>. The files themselves are stored in different places across the web, and you will need to fetch and process the original files yourself. If you are looking for an API directly onto IATI data, you can use the <a href="http://datastore.iatistandard.org/" target="_blank">IATI DataStore</a> or consult the <a href="http://opendevtoolkit.org" target="_blank">Open Development Toolkit</a> to learn about other third-party platforms. If in doubt, ask on IATI <a href="http://discuss.iatistandard.org/">Discuss</a> or email the technical team on <a href="mailto:support@iatistandard.org">support@iatistandard.org</a>.</p>
 
   <p>You can interact with the registry via its API, an implementation of the CKAN API. Full <a href="http://docs.ckan.org/en/latest/api/index.html" target="_blank">CKAN API documentation is available here</a>.</p>
 

--- a/ckanext/iati/theme/templates/static/using-iati-data.html
+++ b/ckanext/iati/theme/templates/static/using-iati-data.html
@@ -22,7 +22,7 @@
 
   <h2>Making direct use of IATI Data</h2>
 
-  <p>There are many third party data tools and resources, including those using IATI data, listed in the <a href="http://opendevtoolkit.net/en-US/tools/">Open Development Toolkit</a>.</p>
+  <p>There are many third party data tools and resources, including those using IATI data, listed in the <a href="http://opendevtoolkit.org">Open Development Toolkit</a>.</p>
 
   <p>Developers can find information on working with IATI data <a href="http://iatistandard.org/201/developer/">here</a> or access help from others in the IATI community in the <a href="http://discuss.iatistandard.org/">Discuss</a> forum.</p>
 


### PR DESCRIPTION
Hello,

Could we merge and deploy this pull request, which fixes links to an external website.

Many thanks,
Dale
IATI Developer